### PR TITLE
appdata: remove U+200B (Unicode Zero-Width Space) characters

### DIFF
--- a/data/com.github.bleakgrey.transporter.appdata.xml.in
+++ b/data/com.github.bleakgrey.transporter.appdata.xml.in
@@ -38,75 +38,75 @@
 
   <releases>
       <release version="1.3.3" date="2018-05-18">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Added custom Download folder support</li>
               <li>Added single file selection support instead of drag and dropping</li>
               <li>Translated into Russian, Lithuanian, French and Italian languages!</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
       <release version="1.3.0" date="2018-04-08">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Added purple accent color</li>
               <li>Added ding after wormhole installation</li>
               <li>Changed headerbar style</li>
               <li>Fixed inconsistent window size</li>
               <li>Fixed a potential crash after wormhole installation</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
       <release version="1.2.2" date="2018-04-06">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Fixed Contractor support for certain files</li>
               <li>Improved searching for magic-wormhole binary</li>
               <li>Improved performance and error handling</li>
               <li>ID entries are now automatically focused</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
       <release version="1.2.1" date="2018-03-16">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Added Contractor support</li>
               <li>Added Send and Receive actions to desktop entry</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
      <release version="1.2.0" date="2018-03-14">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Folders and multiple files support</li>
               <li>Improved UI</li>
               <li>Updated locales</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
      <release version="1.1.1" date="2018-03-11">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Minor UI tweaks</li>
               <li>Corrected typos</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
      <release version="1.1.0" date="2018-03-10">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Added Settings</li>
               <li>Minor bugfixes</li>
           </ul>
-  ​      </description>
-  ​    </release>
+        </description>
+      </release>
     <release version="1.0.0" date="2018-03-01">
-  ​      <description>
-  ​         <ul>
+        <description>
+           <ul>
               <li>Initial release</li>
           </ul>
-  ​      </description>
-  ​    </release>
-  ​ </releases>
+        </description>
+      </release>
+   </releases>
 
 </component>


### PR DESCRIPTION
This fixes parsing the appdata file with libappstream-glib, which is used by gnome-software.